### PR TITLE
Remove photos entitlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Renamr application will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2024-05-16
+
+### Changed
+- Removed photos library access requirement
+- Improved security by removing unnecessary entitlements
+
 ## [1.1.0] - 2024-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ A modern macOS application for batch file renaming with a focus on images and ot
 
 ## Version History
 
+### 1.1.1
+- Removed photos library access requirement
+- Improved security by removing unnecessary entitlements
+
 ### 1.1.0
 - Added automatic underscore insertion
 - Added automatic basename suggestion from folder name

--- a/Renamr/Info.plist
+++ b/Renamr/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1</string>
+    <string>1.1.1</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>
@@ -26,8 +26,6 @@
     <string>Copyright © 2024 Time Lapse Technologies. All rights reserved.</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.utilities</string>
-    <key>NSPhotoLibraryUsageDescription</key>
-    <string>Renamr needs access to your photos to read image metadata for date-based file naming.</string>
     <key>NSAppTransportSecurity</key>
     <dict>
         <key>NSAllowsArbitraryLoads</key>

--- a/Renamr/Renamr.entitlements
+++ b/Renamr/Renamr.entitlements
@@ -8,8 +8,6 @@
     <true/>
     <key>com.apple.security.assets.movies.read-write</key>
     <true/>
-    <key>com.apple.security.assets.pictures.read-write</key>
-    <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
     <key>com.apple.security.cs.allow-jit</key>

--- a/Renamr/RenamrRelease.entitlements
+++ b/Renamr/RenamrRelease.entitlements
@@ -4,8 +4,6 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.assets.pictures.read-write</key>
-	<true/>
 	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>


### PR DESCRIPTION
Updates for 1.1 publish to Apple App Store with unnecessary photos entitlement removed.